### PR TITLE
Fix mismatched braces in Loss Analyzer

### DIFF
--- a/enhanced-loss-extractor-2.html
+++ b/enhanced-loss-extractor-2.html
@@ -1089,7 +1089,6 @@ Waiting for connection test...
             link.click();
             URL.revokeObjectURL(url);
         }
-        }
         
         
         async function analyzeWithOllama() {
@@ -1360,7 +1359,6 @@ Then try the analysis again.`;
                 btn.disabled = false;
                 debugLog('Analysis process ended', 'info');
             }
-        }
         }
         
         // Drag and drop support


### PR DESCRIPTION
## Summary
- fix syntax error by removing stray closing braces in `enhanced-loss-extractor-2.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68440d888254832389105455a84fb573