### PR TITLE
Fix truncated loss output

### DIFF
--- a/enhanced-loss-extractor-2.html
+++ b/enhanced-loss-extractor-2.html
@@ -746,7 +746,7 @@ Waiting for connection test...
         function displayResults() {
             const outputDiv = document.getElementById('output');
             const cleanedDiv = document.getElementById('cleanedOutput');
-            const displayLimit = 50;
+            const displayLimit = chartData.length; // show full data
             let html = '';
             let cleaned = '';
 
@@ -754,11 +754,6 @@ Waiting for connection test...
                 html += `${item.formatted}\n`;
                 cleaned += `${item.step}, ${item.lossValue}\n`;
             });
-
-            if (chartData.length > displayLimit) {
-                html += `\n... and ${chartData.length - displayLimit} more entries`;
-                cleaned += `\n... and ${chartData.length - displayLimit} more entries`;
-            }
 
             outputDiv.textContent = html;
             if (cleanedDiv) cleanedDiv.textContent = cleaned;


### PR DESCRIPTION
## Summary
- remove the 50-result cap from `displayResults`
- show all extracted loss values

## Testing
- `grep -n "more entries" -n enhanced-loss-extractor-2.html`


------
https://chatgpt.com/codex/tasks/task_e_6846b69dfc40832398cd64b84a7bb0f1