### PR TITLE
Add Plotly version of loss grapher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Loss Grapher
 
-This simple HTML tool visualizes training loss values from your logs. Upload a log, and it plots the loss over training steps.
+This project contains simple HTML tools for visualizing training loss values from your logs. Upload a log, and the page plots the loss over training steps. Two versions are provided:
+
+- **enhanced-loss-extractor-2.html** – uses Chart.js with many features including moving averages and AI powered analysis.
+- **loss-grapher-plotly.html** – a lightweight variant built with Plotly.
 
 ## Sample Images
 
 You can overlay sample images generated during training:
-
 
 1. Name image files so that the training step appears as the **second** number when more than one number exists. Examples:
    - `1749459275386__000028500_0.png` (step 28500)
@@ -14,5 +16,4 @@ You can overlay sample images generated during training:
 2. Click **Upload Samples** and select one or more images. You can pick multiple files at once.
 3. Markers will appear on the loss chart at steps where images are available. Click a marker to preview the first four images for that step.
 
-
-Use the HTML file directly in your browser to analyze your logs.
+Use either HTML file directly in your browser to analyze your logs.

--- a/loss-grapher-plotly.html
+++ b/loss-grapher-plotly.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Loss Grapher (Plotly)</title>
+  <script src="https://cdn.plot.ly/plotly-2.25.2.min.js"></script>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 1200px;
+      margin: auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    textarea {
+      width: 100%;
+      height: 150px;
+      margin-bottom: 10px;
+    }
+    #chart {
+      width: 100%;
+      height: 500px;
+    }
+    #imagePreview img {
+      max-width: 200px;
+      margin: 5px;
+    }
+  </style>
+</head>
+<body>
+<h1>Training Loss Grapher (Plotly)</h1>
+<textarea id="logInput" placeholder="Paste training log..."></textarea>
+<div>
+  <button onclick="extractLosses()">Analyze Log</button>
+  <input type="file" id="imageInput" multiple accept="image/*" onchange="handleImageUpload(event)">
+</div>
+<div id="chart"></div>
+<div id="imagePreview"></div>
+<script>
+let chartData = [];
+const stepImages = {};
+function extractStepNumber(filename){
+  const nums = filename.match(/\d+/g);
+  if(!nums) return null;
+  return nums.length>1?parseInt(nums[1]):parseInt(nums[0]);
+}
+function handleImageUpload(e){
+  const files = Array.from(e.target.files);
+  files.forEach(f=>{
+    const step = extractStepNumber(f.name);
+    if(step!==null){
+      const reader = new FileReader();
+      reader.onload=ev=>{
+        if(!stepImages[step]) stepImages[step]=[];
+        if(stepImages[step].length<4) stepImages[step].push(ev.target.result);
+      };
+      reader.readAsDataURL(f);
+    }
+  });
+}
+function extractLosses(){
+  const lines = document.getElementById('logInput').value.split('\n');
+  const lossPattern=/loss:\s*([0-9]+\.?[0-9]*(?:e[+-]?[0-9]+)?)/;
+  const stepPattern=/(\d+)\/(\d+)/;
+  chartData=[];
+  lines.forEach(line=>{
+    const lossMatch=line.match(lossPattern);
+    const stepMatch=line.match(stepPattern);
+    if(lossMatch && stepMatch){
+      chartData.push({step:parseInt(stepMatch[1]),loss:parseFloat(lossMatch[1])});
+    }
+  });
+  if(chartData.length===0){
+    alert('No loss data found');
+    return;
+  }
+  renderChart();
+}
+function renderChart(){
+  const steps=chartData.map(d=>d.step);
+  const losses=chartData.map(d=>d.loss);
+  const trace={
+    x:steps,
+    y:losses,
+    mode:'lines+markers',
+    name:'Loss'
+  };
+  const imgSteps=Object.keys(stepImages).map(s=>parseInt(s));
+  let imgTrace=null;
+  if(imgSteps.length){
+    const imgY=imgSteps.map(s=>{
+      const idx=steps.indexOf(s);
+      return idx!==-1?losses[idx]:null;
+    });
+    imgTrace={
+      x:imgSteps,
+      y:imgY,
+      mode:'markers',
+      marker:{size:10,color:'orange'},
+      name:'Samples',
+      customdata:imgSteps
+    };
+  }
+  const data=imgTrace?[trace,imgTrace]:[trace];
+  Plotly.newPlot('chart',data,{xaxis:{title:'Step'},yaxis:{title:'Loss'}});
+  const chartDiv=document.getElementById('chart');
+  chartDiv.on('plotly_click',data=>{
+    const pts=data.points[0];
+    if(pts.data.name==='Samples'){
+      const step=pts.customdata;
+      showImages(step);
+    }
+  });
+}
+function showImages(step){
+  const container=document.getElementById('imagePreview');
+  const imgs=stepImages[step];
+  if(!imgs){
+    container.innerHTML='';
+    return;
+  }
+  container.innerHTML=`<h3>Step ${step}</h3>`+imgs.map(src=>`<img src="${src}">`).join('');
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Plotly-based loss grapher page that supports sample images
- update README with info about both versions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846ef9f1f088323acdd6fe25a8e9741