### PR TITLE
Fix step misalignment for sample images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can overlay sample images generated during training:
    - `1749459275386__000028500_0.png` (step 28500)
    - `1749459275386__000028500_1.png`
    If only one number is found in the filename, that number is used as the step.
+   The grapher assumes images are generated **after** the logged step completes, so each filename's step is mapped to `step - 1` when overlaying.
 2. Click **Upload Samples** and select one or more images. You can pick multiple files at once.
 3. Markers will appear on the loss chart at steps where images are available. Click a marker to preview the first four images for that step.
 

--- a/enhanced-loss-extractor-2.html
+++ b/enhanced-loss-extractor-2.html
@@ -577,6 +577,7 @@ Waiting for connection test...
         let rateChart = null;
         let chartData = [];
         const stepImages = {};
+        let imageLoadPromise = Promise.resolve();
         let showTrendline = false;
         let autoYScale = true;
         let movingAverageWindow = 0;
@@ -586,24 +587,31 @@ Waiting for connection test...
             const numbers = filename.match(/\d+/g);
             if (!numbers) return null;
             const index = numbers.length > 1 ? 1 : 0;
-            return parseInt(numbers[index]);
+            const rawStep = parseInt(numbers[index]);
+            return rawStep > 0 ? rawStep - 1 : rawStep;
         }
 
         function handleImageUpload(event) {
             const files = Array.from(event.target.files);
-            files.forEach(file => {
+            const loaders = files.map(file => new Promise(resolve => {
                 const step = extractStepNumber(file.name);
-                if (step !== null) {
-                    const reader = new FileReader();
-                    reader.onload = e => {
-                        if (!stepImages[step]) stepImages[step] = [];
-                        if (stepImages[step].length < 4) {
-                            stepImages[step].push(e.target.result);
-                        }
-                    };
-                    reader.readAsDataURL(file);
-                }
-            });
+                if (step === null) return resolve();
+                const reader = new FileReader();
+                reader.onload = e => {
+                    if (!stepImages[step]) stepImages[step] = [];
+                    if (stepImages[step].length < 4) {
+                        stepImages[step].push(e.target.result);
+                    }
+                    if (chartData.length > 0) {
+                        createChart();
+                        createRateChart();
+                    }
+                    resolve();
+                };
+                reader.onerror = () => resolve();
+                reader.readAsDataURL(file);
+            }));
+            imageLoadPromise = Promise.all([imageLoadPromise, ...loaders]).then(() => {});
         }
 
         function closeImageOverlay() {
@@ -699,7 +707,7 @@ Waiting for connection test...
             }
         }
         
-        function extractLosses() {
+        async function extractLosses() {
             const logInput = document.getElementById('logInput').value;
             const mainContent = document.getElementById('mainContent');
             
@@ -739,7 +747,9 @@ Waiting for connection test...
                 alert('No loss values found in the log data. Make sure your log contains lines with "loss:" and step information.');
                 return;
             }
-            
+
+            await imageLoadPromise;
+
             chartData = lossData;
             mainContent.classList.remove('hidden');
             

--- a/loss-grapher-plotly.html
+++ b/loss-grapher-plotly.html
@@ -40,26 +40,32 @@
 <script>
 let chartData = [];
 const stepImages = {};
+let imageLoadPromise = Promise.resolve();
 function extractStepNumber(filename){
   const nums = filename.match(/\d+/g);
   if(!nums) return null;
-  return nums.length>1?parseInt(nums[1]):parseInt(nums[0]);
+  const rawStep = nums.length>1?parseInt(nums[1]):parseInt(nums[0]);
+  return rawStep>0?rawStep-1:rawStep;
 }
 function handleImageUpload(e){
   const files = Array.from(e.target.files);
-  files.forEach(f=>{
+  const loaders = files.map(f=>new Promise(resolve=>{
     const step = extractStepNumber(f.name);
-    if(step!==null){
-      const reader = new FileReader();
-      reader.onload=ev=>{
-        if(!stepImages[step]) stepImages[step]=[];
-        if(stepImages[step].length<4) stepImages[step].push(ev.target.result);
-      };
-      reader.readAsDataURL(f);
-    }
-  });
+    if(step===null) return resolve();
+    const reader = new FileReader();
+    reader.onload=ev=>{
+      if(!stepImages[step]) stepImages[step]=[];
+      if(stepImages[step].length<4) stepImages[step].push(ev.target.result);
+      if(chartData.length) renderChart();
+      resolve();
+    };
+    reader.onerror=()=>resolve();
+    reader.readAsDataURL(f);
+  }));
+  imageLoadPromise = Promise.all([imageLoadPromise, ...loaders]).then(()=>{});
 }
-function extractLosses(){
+async function extractLosses(){
+  await imageLoadPromise;
   const lines = document.getElementById('logInput').value.split('\n');
   const lossPattern=/loss:\s*([0-9]+\.?[0-9]*(?:e[+-]?[0-9]+)?)/;
   const stepPattern=/(\d+)\/(\d+)/;


### PR DESCRIPTION
## Summary
- subtract one from parsed sample image steps to line up with logged loss steps
- document the one-step adjustment in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fd071f748323b60586f9030a722f