### PR TITLE
Fix step indicator mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You can overlay sample images generated during training:
    - `1749459275386__000028500_0.png` (step 28500)
    - `1749459275386__000028500_1.png`
    If only one number is found in the filename, that number is used as the step.
-   The grapher assumes images are generated **after** the logged step completes, so each filename's step is mapped to `step - 1` when overlaying.
+   The grapher now uses the step number as-is. If your images are generated after the
+   loss line for a step, subtract one when naming the files so the markers align.
 2. Click **Upload Samples** and select one or more images. You can pick multiple files at once.
 3. Markers will appear on the loss chart at steps where images are available. Click a marker to preview the first four images for that step.
 

--- a/enhanced-loss-extractor-2.html
+++ b/enhanced-loss-extractor-2.html
@@ -664,7 +664,7 @@ Waiting for connection test...
             if (!numbers) return null;
             const index = numbers.length > 1 ? 1 : 0;
             const rawStep = parseInt(numbers[index]);
-            return rawStep > 0 ? rawStep - 1 : rawStep;
+            return rawStep;
         }
 
         function handleImageUpload(event) {

--- a/loss-grapher-plotly.html
+++ b/loss-grapher-plotly.html
@@ -45,7 +45,7 @@ function extractStepNumber(filename){
   const nums = filename.match(/\d+/g);
   if(!nums) return null;
   const rawStep = nums.length>1?parseInt(nums[1]):parseInt(nums[0]);
-  return rawStep>0?rawStep-1:rawStep;
+  return rawStep;
 }
 function handleImageUpload(e){
   const files = Array.from(e.target.files);


### PR DESCRIPTION
## Summary
- remove step offset when extracting image step numbers
- clarify README instructions about step mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847167f5afc832388a640d97a883957